### PR TITLE
Rename the default config file name to `.launchable.d/config.yml`

### DIFF
--- a/launchable_cli_args/cli_args.py
+++ b/launchable_cli_args/cli_args.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import subprocess
 from typing import Callable, Optional, Tuple, Union
 
@@ -71,7 +72,9 @@ class CLIArgs:
         writer.end_object()
 
     def write_as_yaml(self, path: str):
-        with open(path, 'w') as s:
+        p = Path(path).resolve()
+        p.parents[0].mkdir(parents=True, exist_ok=True)
+        with p.open('w') as s:
             self.write_to(YamlWriter(s))
 
     # read value from dictionary and verify the content.

--- a/launchable_config/__main__.py
+++ b/launchable_config/__main__.py
@@ -8,7 +8,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description='generate/verify launchable test runner configuration file')
     parser.add_argument('--file', dest="file",
-                        default=".launchable-config.yml", help='configuration file name')
+                        default=".launchable.d/config.yml", help='configuration file name')
     parser.add_argument('--create', action="store_true",
                         help='create new configuration file by standard settings')
     parser.add_argument('--verify', action="store_true",

--- a/launchable_config/__main__.py
+++ b/launchable_config/__main__.py
@@ -8,7 +8,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description='generate/verify launchable test runner configuration file')
     parser.add_argument('--file', dest="file",
-                        default="launchable.conf", help='configuration file name')
+                        default=".launchable-config.yml", help='configuration file name')
     parser.add_argument('--create', action="store_true",
                         help='create new configuration file by standard settings')
     parser.add_argument('--verify', action="store_true",

--- a/pytest_launchable/launchable_test_context.py
+++ b/pytest_launchable/launchable_test_context.py
@@ -234,7 +234,7 @@ def pytest_addoption(parser):
                     action="store",
                     dest="launchable_conf_path",
                     metavar="",
-                    default="launchable.conf",
+                    default=".launchable-config.yml",
                     help="path of launchable test configuration file")
 
 

--- a/pytest_launchable/launchable_test_context.py
+++ b/pytest_launchable/launchable_test_context.py
@@ -234,7 +234,7 @@ def pytest_addoption(parser):
                     action="store",
                     dest="launchable_conf_path",
                     metavar="",
-                    default=".launchable-config.yml",
+                    default=".launchable.d/config.yml",
                     help="path of launchable test configuration file")
 
 


### PR DESCRIPTION
As @Konboi and I discussed, the config file should be `.launchable/config.yml`. However, I found Launchable CLI uses `.launchable` as a test session store. They are conflicting. So, I named the config file as `.launchable-config.yml`.