### PR TITLE
Set default mode to record-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ target/
 profile_default/
 ipython_config.py
 
+# Launchable
+.launchable.d/
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:

--- a/launchable_cli_args/subset.py
+++ b/launchable_cli_args/subset.py
@@ -29,10 +29,10 @@ class SubsetArgs:
                     "one of target/confidence/time must be specified")
 
     def write_to(self, writer: YamlWriter):
-        writer.comment("mode is subset, subset-and-rest, or record-only")
+        writer.comment("mode can be subset, subset-and-rest, or record-only")
         writer.name("mode").value(self.mode)
 
-        writer.comment("you must specify one of target/confidence/time")
+        writer.comment("if mode is subset or subset-and-rest, you must specify one of target/confidence/time")
         writer.comment("examples:")
         writer.comment(
             "  target: 30%  # Create a variable time-based subset of the given percentage. (0%-100%)")
@@ -68,6 +68,6 @@ class SubsetArgs:
     @classmethod
     def auto_configure(cls, parent: 'CLIArgs', path: str) -> "SubsetArgs":
         a = SubsetArgs(parent)
-        a.target = "30%"
-        a.mode = "subset"
+        a.mode = "record-only"
+        a.confidence = 99
         return a

--- a/launchable_cli_args/subset.py
+++ b/launchable_cli_args/subset.py
@@ -32,7 +32,8 @@ class SubsetArgs:
         writer.comment("mode can be subset, subset-and-rest, or record-only")
         writer.name("mode").value(self.mode)
 
-        writer.comment("if mode is subset or subset-and-rest, you must specify one of target/confidence/time")
+        writer.comment(
+            "if mode is subset or subset-and-rest, you must specify one of target/confidence/time")
         writer.comment("examples:")
         writer.comment(
             "  target: 30%  # Create a variable time-based subset of the given percentage. (0%-100%)")

--- a/pytest_launchable/launchable_test_context.py
+++ b/pytest_launchable/launchable_test_context.py
@@ -271,7 +271,7 @@ def init_launchable_test_context(items: List[pytest.Function]) -> "LaunchableTes
 
 # called for each test file... this hook can be used to collect full path of tests
 # def pytest_collect_file(path):
-#	print("collect_file path=%s testcasecount=%d" % (path, len(lc.test_node_list))) # 'path' is full path
+# print("collect_file path=%s testcasecount=%d" % (path, len(lc.test_node_list))) # 'path' is full path
 
 # this hook receives test case list
 # we get a chance of reordering or subsetting at this point
@@ -309,9 +309,9 @@ def pytest_collection_modifyitems(config, items: List[pytest.Function]) -> None:
             raw_subset_result.stdout, cli.subset.REST_FILE_NAME)
     else:
         lc.set_subset_command_response(raw_subset_result.stdout)
-    #print("input_file_list=" + str(file_list))
-    #print("output_file_list=" + str(lc.subset_list))
-    #print("all collected names " + str(lc.to_name_tuple_list()))
+    # print("input_file_list=" + str(file_list))
+    # print("output_file_list=" + str(lc.subset_list))
+    # print("all collected names " + str(lc.to_name_tuple_list()))
 
     # find testcase , mark category name, and return pytest object
     def find_and_mark(nodeid: str, category: str):

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -20,17 +20,18 @@ def test_command() -> None:
     args = CLIArgs.auto_configure("tests")
     args.build_id = "XXX"  # manually configured build id
 
-    # at the present, test only subset mode command.
+    # at present, test only subset mode command.
 
-    # default is subset mode
+    # record-only mode (default) / skip subset service, record test command only
+    args.subset.mode = "record-only"
+    assert args.subset.to_command() == ()
+
+    # subset mode
+    args.subset.mode = "subset"
     assert args.subset.to_command() == ("launchable", "subset", "--build",
-                                        "XXX", "--target", "30%", "pytest")
+                                        "XXX", "--confidence", 99, "pytest")
 
     # subset-and-rest mode
     args.subset.mode = "subset-and-rest"
     assert args.subset.to_command() == ("launchable", "subset", "--build", "XXX",
-                                        "--target", "30%", "--rest", args.subset.REST_FILE_NAME, "pytest")
-
-    # record-only mode / skip subset service, record test command only
-    args.subset.mode = "record-only"
-    assert args.subset.to_command() == ()
+                                        "--confidence", 99, "--rest", args.subset.REST_FILE_NAME, "pytest")

--- a/tests/test_launchable_pytest.py
+++ b/tests/test_launchable_pytest.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Optional, Callable
 import pytest
 from pytest_launchable.launchable_test_context import PytestTestPath, init_launchable_test_context, parse_pytest_item
 
@@ -18,7 +18,7 @@ class T:
 class PseudoPytest:
     """make pseudo pytest item"""
 
-    def __init__(self, file: str, name: str, func_or_method: Callable, parameters: str = None):
+    def __init__(self, file: str, name: str, func_or_method: Callable, parameters: Optional[str] = None):
         class_name = func_or_method.__self__.__class__.__name__ if hasattr(  # type: ignore
             func_or_method, "__self__") else None
         function = name + f'[{parameters}]' if parameters else name

--- a/tests/test_yaml_write_load.py
+++ b/tests/test_yaml_write_load.py
@@ -2,7 +2,7 @@ import io
 from yaml2obj.loader import YamlLoaderWithLineNumber
 from yaml2obj.writer import YamlWriter
 
-#　Write YAML and read it with line numbers
+# 　Write YAML and read it with line numbers
 
 
 def test_yaml_read_write():
@@ -15,7 +15,7 @@ def test_yaml_read_write():
 
 
 # expected yaml
-#key0: value0
+# key0: value0
 # key1:
 #  key11: value11
 


### PR DESCRIPTION
Record-only enables most features. We don't want users to subset by default. They will enable it later.

```
awilkes@MacBook-Pro-2 pytest-launchable % python3 -m launchable_config --create                                        
Launchable configuration file is written to /Users/awilkes/code/launchable/pytest-launchable/.launchable.d/config.yml
awilkes@MacBook-Pro-2 pytest-launchable % cat /Users/awilkes/code/launchable/pytest-launchable/.launchable.d/config.yml
# Launchable test session configuration file
# See https://docs.launchableinc.com/resources/cli-reference for detailed usage of these options
#  
schema-version: 1.0
build-name: commit_hash
record-build:
  # Put your git repository location here
  source: .
  max_days: 30
record-session:
subset:
  # mode is subset, subset-and-rest, or record-only
  mode: record-only
  # if mode is subset or subset-and-rest, you must specify one of target/confidence/time
  # examples:
  #   target: 30%  # Create a variable time-based subset of the given percentage. (0%-100%)
  #   confidence: 30%  # Create a confidence-based subset of the given percentage. (0%-100%)
  #   time: 30m  # Create a fixed time-based subset. Select the best set of tests that run within the given time bound. (e.g. 10m for 10 minutes, 2h30m for 2.5 hours, 1w3d for 7+3=10 days. )
record-tests:
  # The test results are placed here in JUnit XML format
  result_dir: launchable-test-result
```